### PR TITLE
Set `TreatWarningsAsErrors` to default to true across repo

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+    <PropertyGroup>
+        <Nullable>enable</Nullable>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
The build props file is used by the compiler to set build properties for all projects in the repo. Any property valid in a `csproj` file is valid here too