### PR TITLE
Add architecture decision records

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+docs/adrs

--- a/README.md
+++ b/README.md
@@ -49,3 +49,9 @@ Data validation is performed at each stage, preventing the user from continuing
 until all information has been supplied in the correct format. As a result,
 Stage 7 (approval) can be assumed to occur automatically once the first 6 stages
 are complete.
+
+## Architecture decision records
+
+We use ADRs to document architectural decisions that we make. They can be found in
+[docs/adrs](docs/adrs) and contributed to with the
+[adr-tools](https://github.com/npryce/adr-tools).

--- a/docs/adrs/0001-record-architecture-decisions.md
+++ b/docs/adrs/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2024-05-10
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).


### PR DESCRIPTION
- Use the [adr-tools](https://github.com/npryce/adr-tools) to create the first ADR and `.adr-dir`.
- Update the README to describe our use of ADRs.

This reflects our usual way of setting up ADRs at dxw. For example, in the [Ruby on Rails template](https://github.com/dxw/rails-template)